### PR TITLE
Implement RTC setting

### DIFF
--- a/systest/battclock.c
+++ b/systest/battclock.c
@@ -594,7 +594,7 @@ static void inc_dec_year(enum bc_type bc_type, uint32_t base, int8_t amount)
         yr = ((rp5c01->yr10 & 0xf) * 10) + (rp5c01->yr1 & 0xf);
         yr += (yr < 78) ? 2000 : 1900;        /* 0 <= yr <= 99 --> 1978-2077 */
 
-		yr += amount;
+	    yr += amount;
         if (yr > 2077)
             yr = 1978;
 

--- a/systest/battclock.c
+++ b/systest/battclock.c
@@ -55,6 +55,17 @@ enum bc_type {
     BC_NONE
 };
 
+const static uint8_t days_in_month[] = {
+	31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+};
+const static char *mon_str[] = {
+	"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+};
+const static char *day_week_str[] = {
+	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+};
+
 /* This function has to be careful: 
  * 1. We do not know whether we have a RP5C01 or MSM6242 chip, and they are 
  *    not register compatible. 
@@ -180,17 +191,6 @@ static int bc_time_is_bogus(enum bc_type bc_type, uint32_t base)
 
 static void bc_get_time(enum bc_type bc_type, uint32_t base, char *s)
 {
-    const static uint8_t days_in_month[] = {
-        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
-    };
-    const static char *mon_str[] = {
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    };
-    const static char *day_week_str[] = {
-        "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-    };
-
     uint32_t days_since_1900;
     uint8_t sec, min, hr, day, day_week, mon, hr24, t;
     uint16_t yr;
@@ -318,6 +318,327 @@ static void bc_reset(enum bc_type bc_type, uint32_t base)
     }
 }
 
+/* Call this with the full actual 4-digit year */
+static uint8_t get_day_of_week(uint8_t day, uint8_t mon, uint16_t yr)
+{
+    uint32_t days_since_1900;
+    uint8_t day_week;
+    uint8_t t;
+
+     /* Workbench ignores the day-of-week register and does not set it.
+     * So calculate the day-of-week ourselves. */
+    days_since_1900 = (uint32_t)(yr - 1900) * 365; /* years */
+    if (yr >= 1904)
+        days_since_1900 += (yr - 1901 + (mon >= 2)) >> 2; /* leap years */
+    for (t = 0; t < mon; t++)
+        days_since_1900 += days_in_month[t]; /* months */
+    days_since_1900 += day - 1; /* day of month */
+    days_since_1900 += 1; /* 1 Jan 1900 was a Monday */
+    day_week = do_div(days_since_1900, 7);
+
+    return day_week;
+}
+
+static void inc_hours(enum bc_type bc_type, uint32_t base)
+{
+    uint8_t hr, hr24;
+
+    switch (bc_type) {
+    case BC_RP5C01: {
+        volatile struct rp5c01 *rp5c01 = (struct rp5c01 *)base;
+        // Get current hour
+        rp5c01->ctl_d = 1; /* stop timer, mode 01 */
+        hr24 = rp5c01->mon10 & 1;
+        if (hr24) {
+            hr = ((rp5c01->hr10 & 0x3) * 10) + (rp5c01->hr1 & 0xf);
+        } else {
+            hr = ((rp5c01->hr10 & 0x1) * 10) + (rp5c01->hr1 & 0xf);
+            if (rp5c01->hr10 & 0x2)
+                hr += 12;
+        }
+
+        // Increase
+        if (++hr > 23)
+            hr = 0;
+
+        // Set
+        rp5c01->ctl_d = 0; /* stop timer, mode 00 */
+        if (hr24 || hr <= 12) {
+            rp5c01->hr1 = do_div(hr, 10);    /* AM flag set implicitly */
+            rp5c01->hr10 = hr;
+        } else {
+            // Set PM flag
+            hr -= 12;
+            rp5c01->hr1 = do_div(hr, 10);
+            rp5c01->hr10 = hr | 0x2;
+        }
+
+
+        rp5c01->ctl_d = 8; /* restart timer */
+        break;
+    }
+    case BC_MSM6242: {
+        volatile struct msm6242 *msm6242 = (struct msm6242 *)base;
+        uint8_t t;
+        hr24 = !!(msm6242->ctl_f & 4);
+        msm6242->ctl_d = 1; /* set HOLD */
+        t = 10;
+        while ((msm6242->ctl_d & 2) && --t) { /* wait 10ms for !BUSY */
+            msm6242->ctl_d = 0;
+            delay_ms(1);
+            msm6242->ctl_d = 1;
+        }
+        if (hr24) {
+            hr = ((msm6242->hr10 & 0x3) * 10) + (msm6242->hr1 & 0xf);
+        } else {
+            hr = ((msm6242->hr10 & 0x1) * 10) + (msm6242->hr1 & 0xf);
+            if (msm6242->hr10 & 0x4)
+                hr += 12;
+        }
+        if (++hr > 23)
+            hr = 0;
+
+        if (hr24 || hr <= 12) {
+            msm6242->hr1 = do_div(hr, 10);
+            msm6242->hr10 = hr;
+        } else {
+            hr -= 12;
+            msm6242->hr1 = do_div(hr, 10);
+            msm6242->hr10 = hr | 0x4;
+        }
+
+        msm6242->ctl_d = 0; /* clear HOLD */
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+static void inc_minutes(enum bc_type bc_type, uint32_t base)
+{
+    uint8_t min;
+
+    switch (bc_type) {
+    case BC_RP5C01: {
+        volatile struct rp5c01 *rp5c01 = (struct rp5c01 *)base;
+        // Get current value
+        rp5c01->ctl_d = 0; /* stop timer, mode 00 */
+        min = ((rp5c01->min10 & 0xf) * 10) + (rp5c01->min1 & 0xf);
+
+        // Increase
+        if (++min > 59)
+            min = 0;
+
+        // Set
+        rp5c01->min1 = do_div(min, 10);
+        rp5c01->min10 = min;
+
+        // Also reset seconds
+        rp5c01->sec10 = rp5c01->sec1 = 0;
+
+        rp5c01->ctl_d = 8; /* restart timer */
+        break;
+    }
+    case BC_MSM6242: {
+        volatile struct msm6242 *msm6242 = (struct msm6242 *)base;
+        uint8_t t;
+        msm6242->ctl_d = 1; /* set HOLD */
+        t = 10;
+        while ((msm6242->ctl_d & 2) && --t) { /* wait 10ms for !BUSY */
+            msm6242->ctl_d = 0;
+            delay_ms(1);
+            msm6242->ctl_d = 1;
+        }
+        min = ((msm6242->min10 & 0xf) * 10) + (msm6242->min1 & 0xf);
+        if (++min > 59)
+            min = 0;
+        msm6242->min1 = do_div(min, 10);
+        msm6242->min10 = min;
+        msm6242->sec10 = msm6242->sec1 = 0;
+        msm6242->ctl_d = 0; /* clear HOLD */
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+static void inc_day(enum bc_type bc_type, uint32_t base)
+{
+    uint8_t day, mon;
+    uint16_t yr;
+
+    switch (bc_type) {
+    case BC_RP5C01: {
+        volatile struct rp5c01 *rp5c01 = (struct rp5c01 *)base;
+        rp5c01->ctl_d = 0; /* stop timer, mode 00 */
+        day = ((rp5c01->day10 & 0x3) * 10) + (rp5c01->day1 & 0xf);
+        mon = ((rp5c01->mon10 & 0x1) * 10) + (rp5c01->mon1 & 0xf);
+        if (mon <= 0)        /* Make sure month is in the 1-12 range*/
+            mon = 1;
+        mon %= 12;
+        yr = ((rp5c01->yr10 & 0xf) * 10) + (rp5c01->yr1 & 0xf);
+        yr += (yr < 78) ? 2000 : 1900;        /* 0 <= yr <= 99 --> 1978-2077 */
+
+        if (++day > days_in_month[(mon-1)])
+            day = 1;
+
+        rp5c01->day_of_week = get_day_of_week(day, mon, yr);
+        rp5c01->day1 = do_div(day, 10);
+        rp5c01->day10 = day;
+        rp5c01->ctl_d = 8; /* restart timer */
+        break;
+    }
+    case BC_MSM6242: {
+        volatile struct msm6242 *msm6242 = (struct msm6242 *)base;
+        uint8_t t;
+        msm6242->ctl_d = 1; /* set HOLD */
+        t = 10;
+        while ((msm6242->ctl_d & 2) && --t) { /* wait 10ms for !BUSY */
+            msm6242->ctl_d = 0;
+            delay_ms(1);
+            msm6242->ctl_d = 1;
+        }
+
+        day = ((msm6242->day10 & 0x3) * 10) + (msm6242->day1 & 0xf);
+        mon = ((msm6242->mon10 & 0x1) * 10) + (msm6242->mon1 & 0xf);
+        if (mon <= 0)        /* Make sure month is in the 1-12 range*/
+            mon = 1;
+        mon %= 12;
+        yr = ((msm6242->yr10 & 0xf) * 10) + (msm6242->yr1 & 0xf);
+        yr += (yr < 78) ? 2000 : 1900;
+
+        if (++day > days_in_month[(mon-1)])
+            day = 1;
+
+        msm6242->day_of_week = get_day_of_week(day, mon, yr);
+        msm6242->day1 = do_div(day, 10);
+        msm6242->day10 = day;
+        msm6242->ctl_d = 0; /* clear HOLD */
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+static void inc_month(enum bc_type bc_type, uint32_t base)
+{
+    uint8_t day, mon;
+    uint16_t yr;
+
+    switch (bc_type) {
+    case BC_RP5C01: {
+        volatile struct rp5c01 *rp5c01 = (struct rp5c01 *)base;
+        rp5c01->ctl_d = 0; /* stop timer, mode 00 */
+        day = ((rp5c01->day10 & 0x3) * 10) + (rp5c01->day1 & 0xf);
+        mon = ((rp5c01->mon10 & 0x1) * 10) + (rp5c01->mon1 & 0xf);
+        if (++mon > 12)
+            mon = 1;
+		if (day > days_in_month[(mon-1)])		/* Day might not exist in new month */
+            day = 1;
+        yr = ((rp5c01->yr10 & 0xf) * 10) + (rp5c01->yr1 & 0xf);
+        yr += (yr < 78) ? 2000 : 1900;
+        rp5c01->day_of_week = get_day_of_week(day, mon, yr);
+        rp5c01->day1 = do_div(day, 10);
+        rp5c01->day10 = day;
+        rp5c01->mon1 = do_div(mon, 10);
+        rp5c01->mon10 = mon;
+        rp5c01->ctl_d = 8; /* restart timer */
+        break;
+    }
+    case BC_MSM6242: {
+        volatile struct msm6242 *msm6242 = (struct msm6242 *)base;
+        uint8_t t;
+        msm6242->ctl_d = 1; /* set HOLD */
+        t = 10;
+        while ((msm6242->ctl_d & 2) && --t) { /* wait 10ms for !BUSY */
+            msm6242->ctl_d = 0;
+            delay_ms(1);
+            msm6242->ctl_d = 1;
+        }
+        day = ((msm6242->day10 & 0x3) * 10) + (msm6242->day1 & 0xf);
+        mon = ((msm6242->mon10 & 0x1) * 10) + (msm6242->mon1 & 0xf);
+        if (++mon > 12)
+            mon = 1;
+		if (day > days_in_month[(mon-1)])
+            day = 1;
+        yr = ((msm6242->yr10 & 0xf) * 10) + (msm6242->yr1 & 0xf);
+        yr += (yr < 78) ? 2000 : 1900;
+
+        msm6242->day_of_week = get_day_of_week(day, mon, yr);
+        msm6242->day1 = do_div(day, 10);
+        msm6242->day10 = day;
+        msm6242->mon1 = do_div(mon, 10);
+        msm6242->mon10 = mon;
+        msm6242->ctl_d = 0; /* clear HOLD */
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+static void inc_dec_year(enum bc_type bc_type, uint32_t base, int8_t amount)
+{
+    uint8_t day, mon;
+    uint16_t yr;
+
+    switch (bc_type) {
+    case BC_RP5C01: {
+        volatile struct rp5c01 *rp5c01 = (struct rp5c01 *)base;
+        rp5c01->ctl_d = 0; /* stop timer, mode 00 */
+        day = ((rp5c01->day10 & 0x3) * 10) + (rp5c01->day1 & 0xf);
+        mon = ((rp5c01->mon10 & 0x1) * 10) + (rp5c01->mon1 & 0xf);
+        yr = ((rp5c01->yr10 & 0xf) * 10) + (rp5c01->yr1 & 0xf);
+        yr += (yr < 78) ? 2000 : 1900;        /* 0 <= yr <= 99 --> 1978-2077 */
+
+		yr += amount;
+        if (yr > 2077)
+            yr = 1978;
+
+        rp5c01->day_of_week = get_day_of_week(day, mon, yr);
+
+        yr -= (yr >= 2000) ? 2000 : 1900;
+        rp5c01->yr1 = do_div(yr, 10);
+        rp5c01->yr10 = yr;
+        rp5c01->ctl_d = 8; /* restart timer */
+        break;
+    }
+    case BC_MSM6242: {
+        volatile struct msm6242 *msm6242 = (struct msm6242 *)base;
+        uint8_t t;
+        msm6242->ctl_d = 1; /* set HOLD */
+        t = 10;
+        while ((msm6242->ctl_d & 2) && --t) { /* wait 10ms for !BUSY */
+            msm6242->ctl_d = 0;
+            delay_ms(1);
+            msm6242->ctl_d = 1;
+        }
+        day = ((msm6242->day10 & 0x3) * 10) + (msm6242->day1 & 0xf);
+        mon = ((msm6242->mon10 & 0x1) * 10) + (msm6242->mon1 & 0xf);
+        yr = ((msm6242->yr10 & 0xf) * 10) + (msm6242->yr1 & 0xf);
+        yr += (yr < 78) ? 2000 : 1900;
+
+		yr += amount;
+        if (yr > 2077)
+            yr = 1978;
+
+		yr -= (yr >= 2000) ? 2000 : 1900;
+        msm6242->day_of_week = get_day_of_week(day, mon, yr);
+        msm6242->yr1 = do_div(yr, 10);
+        msm6242->yr10 = yr;
+        msm6242->ctl_d = 0; /* clear HOLD */
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+
+
 void battclock_test(void)
 {
     char s[80];
@@ -346,7 +667,16 @@ void battclock_test(void)
     if (bc_type != BC_NONE) {
         r.x = 9;
         r.y = 8;
-        sprintf(s, "$1 Reset Date & Time$");
+        sprintf(s, "$1 +Hours$   $2 +Minutes$");
+        print_line(&r);
+        r.y++;
+        sprintf(s, "$3 +Day$     $4 +Month$");
+        print_line(&r);
+        r.y++;
+        sprintf(s, "$5 +Year$    $6 -Year$");
+        print_line(&r);
+        r.y += 2;
+        sprintf(s, "$9 Reset Date & Time$");
         print_line(&r);
     }
 
@@ -369,6 +699,24 @@ void battclock_test(void)
         if (key == K_ESC)
             break;
         if (key == K_F1) {
+            inc_hours(bc_type, base);
+        }
+        if (key == K_F2) {
+            inc_minutes(bc_type, base);
+        }
+        if (key == K_F3) {
+            inc_day(bc_type, base);
+        }
+        if (key == K_F4) {
+            inc_month(bc_type, base);
+        }
+        if (key == K_F5) {
+            inc_dec_year(bc_type, base, +1);
+        }
+        if (key == K_F6) {
+            inc_dec_year(bc_type, base, -1);
+        }
+		if (key == K_F9) {
             bc_reset(bc_type, base);
             is_bogus = 0;
             clear_text_rows(6, 1);


### PR DESCRIPTION
Here's my attempt at fixing #4.

I have implemented setting functions for both RTC types, but as my Amiga only has an MSM, I could only test for that one. It works well, except that sometimes the RTC isn't detected. I don't see what I can have changed to trigger that behaviour, as I didn't touch the detection functions. Plus, this only happens on my real Amiga, on UAE the RTC is always detected. Maybe can you help with that? Could it be a problem with the stack?

Anyway, I think the interface is pretty practical, you can set the RTC without too much hassle. Reminds me a bit of cheap watches of the '80s...