### PR TITLE
Fixes a crash on A1200/BlizzardPPC/060

### DIFF
--- a/base/init.S
+++ b/base/init.S
@@ -91,6 +91,24 @@
         move.l  a0,(0x10).w
         dc.l    0x4e7b0801      /* movec.l d0,vbr  (VBR  = 0) */
         dc.l    0x4e7b0002      /* movec.l d0,cacr (CACR = 0) */
+
+        /* Disable 68851/030 MMU */
+        lea     .skip_030_mmu(pc),a0
+        move.l  (0x2c).w,d1     /* Save Line F exception handler */
+        move.l  a0,(0x2c).w     /* New handler */
+.pmoves:dc.l    0xf0004000      /* pmove d0,tc  - 68851 and 68030 */
+        dc.l    0xf0000800      /* pmove d0,tt0 - 68030 specific */
+        dc.l    0xf0000c00      /* pmove d0,tt1 - 68030 specific  */
+.skip_030_mmu:
+        move.l  d1,(0x2c).w     /* Restore Line F exception handler */
+
+        /* Disable 040/060 MMU */
+        dc.l    0x4e7b0003      /* movec.l d0,tc */
+        dc.l    0x4e7b0004      /* movec.l d0,itt0 */
+        dc.l    0x4e7b0005      /* movec.l d0,itt1 */
+        dc.l    0x4e7b0006      /* movec.l d0,dtt0 */
+        dc.l    0x4e7b0007      /* movec.l d0,dtt1 */
+
 .skip:  lea.l   (SUPER_SP).l,sp /* SSP */
         lea.l   (USER_SP).l,a0
         move.l  a0,usp          /* USP */


### PR DESCRIPTION
This PR disables MMU on startup so that ATK works properly on Amiga 1200 with BlizzardPPC and full 68060.
It has also been tested against regression on standard Amiga 1200, Amiga 1200 with 68030, Amiga 4000, and Amiga 500.