### PR TITLE
fix for broken build of testkit with m68k-gcc v9.2.0

### DIFF
--- a/testkit/memory.c
+++ b/testkit/memory.c
@@ -396,7 +396,7 @@ static void memcheck_direct_scan(void)
     for (i = 0; i < 27; i++) {
         if (aliased_slots & (1u << i))
             continue;
-        p = (volatile uint16_t *)s + (i << 18);
+        p = (volatile uint16_t *)0 + (i << 18);
         p[0] = 0x5555;
         p[1<<17] = 0xaaaa;
         if ((p[0] != 0x5555) || (p[1<<17] != 0xaaaa)) {
@@ -404,7 +404,7 @@ static void memcheck_direct_scan(void)
             continue;
         }
         for (j = 0; j < i; j++) {
-            q = (volatile uint16_t *)s + (j << 18);
+            q = (volatile uint16_t *)0 + (j << 18);
             if ((ram_slots & (1u << j)) && (*q == 0x5555))
                 break;
         }


### PR DESCRIPTION
fixes #24 - ATK compile-error memcheck.c
error in testkit/memory.c - bad pointer arithmetic using char-pointer.
fixed by replacing addressing with reference implementation without
char-pointer. successfully tested solution.