### PR TITLE
ATK - fix for broken build with gcc 9.2.0 - issue #24

### DIFF
--- a/testkit/memory.c
+++ b/testkit/memory.c
@@ -396,7 +396,7 @@ static void memcheck_direct_scan(void)
     for (i = 0; i < 27; i++) {
         if (aliased_slots & (1u << i))
             continue;
-        p = (volatile uint16_t *)s + (i << 18);
+        p = (volatile uint16_t *) &s[0] + (i << 18);
         p[0] = 0x5555;
         p[1<<17] = 0xaaaa;
         if ((p[0] != 0x5555) || (p[1<<17] != 0xaaaa)) {


### PR DESCRIPTION
fixes #24 - ATK - compile-error memcheck (memory.c) - 2nd attempt

replaced reference to "s" (char array) by using pointer to first
element. s is known to be in a safe memory area to write to, thus
the checks may start there to write the first patterns.
gcc 9.2.0 complains in using "s" in memory-pointer p with exceeding
array limits - using pointer to first element avoids the check.