### PR TITLE
Added defines for macOS compilation

### DIFF
--- a/host_tools/hunk_loader.c
+++ b/host_tools/hunk_loader.c
@@ -20,6 +20,15 @@
 #include <unistd.h>
 #include <getopt.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+
+#endif
+
 #define HUNK_HEADER       0x3F3
 #define HUNK_UNIT         0x3E7
 

--- a/host_tools/kickconv.c
+++ b/host_tools/kickconv.c
@@ -20,6 +20,15 @@
 #include <unistd.h>
 #include <getopt.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+
+#endif
+
 static uint16_t _swap(uint16_t x)
 {
     return (x >> 8) | (x << 8);


### PR DESCRIPTION
macOS doesn't have some of the endian-related methods used in kickconv.c and hunk_loader.c, but defines similar ones in an OS-provided header.  This includes that OS header and adds some defines to use those methods instead.