### PR TITLE
testkit: floppy test enhancements

### DIFF
--- a/testkit/floppy.c
+++ b/testkit/floppy.c
@@ -340,8 +340,9 @@ static unsigned int drive_signal_test(unsigned int drv, struct char_row *r)
             }
             if ((prb != old_prb) || key) {
                 r->y += 4;
-                sprintf(s, "$7 STEP=%u$  $8 DIR=%u$",
-                        !!(prb & CIABPRB_STEP), !!(prb & CIABPRB_DIR));
+                sprintf(s, "$7 STEP=%u$  $8 DIR=%u$  $9 SIDE=%u$",
+                        !!(prb & CIABPRB_STEP), !!(prb & CIABPRB_DIR),
+                        !!(prb & CIABPRB_SIDE));
                 print_line(r);
                 r->y -= 4;
                 old_prb = prb;
@@ -382,6 +383,9 @@ static unsigned int drive_signal_test(unsigned int drv, struct char_row *r)
                 key = 0; /* don't force print */
             } else if (key == 0x57) { /* F8 */
                 ciab->prb ^= CIABPRB_DIR;
+                key = 0; /* don't force print */
+            } else if (key == 0x58) { /* F9 */
+                ciab->prb ^= CIABPRB_SIDE;
                 key = 0; /* don't force print */
             } else if (key == K_ESC) { /* ESC */
                 break;

--- a/testkit/floppy.c
+++ b/testkit/floppy.c
@@ -331,18 +331,21 @@ static unsigned int drive_signal_test(unsigned int drv, struct char_row *r)
                         motors&(1u<<2) ? '2' : ' ',
                         motors&(1u<<3) ? '3' : ' ',
                         pra,
-                        ~pra & CIAAPRA_CHNG ? "CHG" : "",
-                        ~pra & CIAAPRA_WPRO ? "WPR" : "",
-                        ~pra & CIAAPRA_TK0  ? "TK0" : "",
-                        ~pra & CIAAPRA_RDY  ? "RDY" : "");
+                        ~pra & CIAAPRA_CHNG ? "/CHG" : "",
+                        ~pra & CIAAPRA_WPRO ? "/WPR" : "",
+                        ~pra & CIAAPRA_TK0  ? "/TK0" : "",
+                        ~pra & CIAAPRA_RDY  ? "/RDY" : "");
                 print_line(r);
                 old_pra = pra;
             }
             if ((prb != old_prb) || key) {
                 r->y += 4;
-                sprintf(s, "$7 STEP=%u$  $8 DIR=%u$  $9 SIDE=%u$",
-                        !!(prb & CIABPRB_STEP), !!(prb & CIABPRB_DIR),
-                        !!(prb & CIABPRB_SIDE));
+                sprintf(s, "$7 /STEP=%c$  $8 DIR=%c (%c1)$  $9 /SIDE=%c (head %s)$",
+                        prb & CIABPRB_STEP ? 'H' : 'L',
+                        prb & CIABPRB_DIR ? 'H' : 'L',
+                        prb & CIABPRB_DIR ? '-' : '+',
+                        prb & CIABPRB_SIDE ? 'H' : 'L',
+                        prb & CIABPRB_SIDE ? "0/lower" : "1/upper");
                 print_line(r);
                 r->y -= 4;
                 old_prb = prb;

--- a/testkit/floppy.c
+++ b/testkit/floppy.c
@@ -335,6 +335,7 @@ static unsigned int drive_signal_test(unsigned int drv, struct char_row *r)
                         ~pra & CIAAPRA_WPRO ? "/WPR" : "",
                         ~pra & CIAAPRA_TK0  ? "/TK0" : "",
                         ~pra & CIAAPRA_RDY  ? "/RDY" : "");
+                wait_bos();
                 print_line(r);
                 old_pra = pra;
             }
@@ -346,6 +347,7 @@ static unsigned int drive_signal_test(unsigned int drv, struct char_row *r)
                         prb & CIABPRB_DIR ? '-' : '+',
                         prb & CIABPRB_SIDE ? 'H' : 'L',
                         prb & CIABPRB_SIDE ? "0/lower" : "1/upper");
+                wait_bos();
                 print_line(r);
                 r->y -= 4;
                 old_prb = prb;
@@ -360,6 +362,7 @@ static unsigned int drive_signal_test(unsigned int drv, struct char_row *r)
                         !!(motors&(1u<<drv)) ? "On" : "Off",
                         !!(old_pra & CIAAPRA_RDY), rdystr);
                 r->y++;
+                wait_bos();
                 print_line(r);
                 r->y--;
                 old_disk_index_count = disk_index_count;


### PR DESCRIPTION
Floppy test enhancements:

* Add SIDE control to floppy signal test
* Clarify signals in floppy signal test
* Allow selecting one or both heads in floppy calibration test
* Avoid flicker when updating screen
* Add "Auto re-seek" option to floppy calibration test.

I can split these into separate pull requests if you prefer.