### PR TITLE
Better Chipset Test and keep RTC up to date

### DIFF
--- a/testkit/Makefile
+++ b/testkit/Makefile
@@ -1,6 +1,9 @@
 NAME := AmigaTestKit
 VER := $(shell git rev-parse --short HEAD)
 
+# Year to set when RTC is reset (F1 in battery clock test)
+RTC_RESET_YEAR ?= $(shell date +%Y)
+
 OBJS += entry.o
 OBJS += cancellation.o
 OBJS += util.o
@@ -28,7 +31,7 @@ include ../base/Rules.mk
 all: $(NAME)-$(VER).zip
 
 build.o: CFLAGS += -DVER="\"$(VER)\""
-
+battclock.o: CFLAGS += -DRTC_RESET_YEAR=$(RTC_RESET_YEAR)
 entry.o: AFLAGS += -DDETECT_MEMORY
 
 $(NAME)-$(VER).zip: $(NAME).adf $(NAME) $(NAME).info README.md $(NAME).elf

--- a/testkit/battclock.c
+++ b/testkit/battclock.c
@@ -14,6 +14,10 @@
 
 #include "testkit.h"
 
+#ifndef RTC_RESET_YEAR
+#define RTC_RESET_YEAR 2016
+#endif
+
 struct time {
     uint8_t sec;   /* 0-59 */
     uint8_t min;   /* 0-59 */
@@ -541,10 +545,10 @@ redisplay:
             break;
         switch (key) {
         case K_F1:
-            /* Fri Jan 1 00:00:00 2016 */
+            /* Reset to Jan 1 00:00:00 of configured year */
             memset(&time, 0, sizeof(time));
             time.mday = 1;
-            time.year = 2016;
+            time.year = RTC_RESET_YEAR;
             bc_set_time(&bc, &time);
             is_bogus = 0;
             clear_text_rows(6, 1);

--- a/testkit/cia.c
+++ b/testkit/cia.c
@@ -493,16 +493,37 @@ void ciacheck(void)
         print_line(&r);
 
         /* Chipset IDs. */
+        lisaid = cust->deniseid;
+        aliceid = (cust->vposr >> 8) & 0x7f;
         r.y += 2;
         sprintf(s, "-- Chipset IDs --");
         print_line(&r);
         r.y++;
-        lisaid = cust->deniseid;
-        sprintf(s, "Denise/Lisa: %04x", lisaid);
+        if (aliceid >= 0x22)
+            sprintf(s, "Lisa: %04x", lisaid);
+        else if (lisaid & 2)
+            sprintf(s, "Denise (OCS): %04x", lisaid);
+        else
+            sprintf(s, "Super Denise (ECS): %04x", lisaid);
         print_line(&r);
         r.y++;
-        aliceid = (cust->vposr >> 8) & 0x7f;
-        sprintf(s, "Agnus/Alice: %04x", aliceid);
+        switch (aliceid) {
+        case 0x00:
+        case 0x10:
+            sprintf(s, "Agnus (OCS): %04x", aliceid);
+            break;
+        case 0x20:
+        case 0x21:
+            sprintf(s, "Agnus (ECS): %04x", aliceid);
+            break;
+        case 0x22:
+        case 0x23:
+            sprintf(s, "Alice: %04x", aliceid);
+            break;
+        default:
+            sprintf(s, "Agnus/Alice (unknown): %04x", aliceid);
+            break;
+        }
         print_line(&r);
         if (/* Detect AGA Alice IDs: 0x22, 0x23, 0x32, 0x33. */
             ((aliceid & 0x6e) == 0x22)


### PR DESCRIPTION
Show more detail on the custom chips found in the system
Also reset RTC to the current year. This was a wish specifically from Kavanoz
who is building a ton of Amiga boards and for whom AmigaTestKit is a life line

- **testkit: improve Denise/Lisa/Agnus/Alice detection**
- **testkit: Add SuperDMAC check**
- **testkit: Make RTC reset year configurable**
